### PR TITLE
Update TZToxicZoneClient.c

### DIFF
--- a/ToxicZone/scripts/4_World/classes/SystemTZHandler/Core/TZToxicZoneClient.c
+++ b/ToxicZone/scripts/4_World/classes/SystemTZHandler/Core/TZToxicZoneClient.c
@@ -190,15 +190,19 @@ class TZToxicZoneClient
       }
     }
 
-    void ClothesCheckClient(PlayerBase player)
+	void ClothesCheckClient(PlayerBase player)
     {
-        ClothesProtection=0;
-        for (int i = 0; i <GetTZClothesConfigClient().TZListSlotProtection.Count() ;i++)
+        ClothesProtection = 0;
+        int count = GetTZClothesConfigClient().TZListSlotProtection.Count();
+        for (int i = 0; i < count; i++)
         {
-          EntityAI SuitsPart;
-          string slotname = GetTZClothesConfigClient().TZListSlotProtection.Get(i).SlotName;
-          SuitsPart = player.FindAttachmentBySlotName(slotname);
-          ClothesProtection += GetProtectionLevel(SuitsPart, i, slotname);
+            string slotname = GetTZClothesConfigClient().TZListSlotProtection.Get(i).SlotName;
+            if (IsOnlyGasMask && slotname != "Mask")
+            {
+                continue;
+            }
+            EntityAI SuitsPart = player.FindAttachmentBySlotName(slotname);
+            ClothesProtection += GetProtectionLevel(SuitsPart, i, slotname);
         }
     }
 
@@ -309,4 +313,5 @@ class TZToxicZoneClient
       GetRPCManager().SendRPC("TZToxicZone", "GetSickQtyToGive", new Param1<float>(toxictogive), true);
     }
 };
+
 


### PR DESCRIPTION
Updated `ClothesCheckClient` logic to strictly enforce mask requirements in `IsOnlyGasMask` zones.

Previously, players wearing NBC gear (jackets, pants, etc.) were calculated as having sufficient protection even without a mask, because the total protection score exceeded the required threshold (1).

The new logic explicitly ignores all equipment slots except "Mask" when `IsOnlyGasMask` is enabled. This ensures that protection defaults to 0 if a valid mask (with filter) is not present, correctly triggering sickness.